### PR TITLE
feat: adiciona envio de emails no fluxo de auto cadastro

### DIFF
--- a/src/main/java/reserva_api/cors/CorsFilter.java
+++ b/src/main/java/reserva_api/cors/CorsFilter.java
@@ -13,12 +13,13 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import reserva_api.utils.Constantes;
 
 @Component
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class CorsFilter implements Filter {
 
-	private String originPermitida = "*"; // TODO: Configurar para diferentes ambientes
+	private String originPermitida = Constantes.urlFront; // TODO: Configurar para diferentes ambientes
 
     @Override
     public void doFilter(ServletRequest req, ServletResponse resp, FilterChain chain)

--- a/src/main/java/reserva_api/dtos/EnviaEmailsAutoCadastroDto.java
+++ b/src/main/java/reserva_api/dtos/EnviaEmailsAutoCadastroDto.java
@@ -1,0 +1,16 @@
+package reserva_api.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class EnviaEmailsAutoCadastroDto {
+    @NotBlank(message = "O campo E-mail é obrigatório")
+    private String email;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/reserva_api/dtos/EnviaEmailsUpdateStatusDto.java
+++ b/src/main/java/reserva_api/dtos/EnviaEmailsUpdateStatusDto.java
@@ -1,0 +1,15 @@
+package reserva_api.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class EnviaEmailsUpdateStatusDto {
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/reserva_api/resources/ComunicacaoInternaResource.java
+++ b/src/main/java/reserva_api/resources/ComunicacaoInternaResource.java
@@ -13,6 +13,7 @@ import reserva_api.services.ComunicacaoInternaService;
 import reserva_api.services.EnviaEmailService;
 import reserva_api.services.PessoaService;
 import reserva_api.utils.ApiError;
+import reserva_api.utils.Constantes;
 import reserva_api.utils.MensagemEmailUtil;
 
 import java.util.List;
@@ -45,7 +46,7 @@ public class ComunicacaoInternaResource {
         comunicacoInternaModel.setPessoa(pessoaModelOptional.get());
 
         enviaEmailService.enviar(
-                "comunicacaointernaicet@gmail.com", // e-mail da comunicacao interna
+                Constantes.adminEmail, // e-mail do admin
                 comunicacoInternaModel.getAssunto(),
                 MensagemEmailUtil.solicitacaoComunicacaoInterna(comunicacoInternaModel)
         );

--- a/src/main/java/reserva_api/security/WebSecurityConfiguracao.java
+++ b/src/main/java/reserva_api/security/WebSecurityConfiguracao.java
@@ -44,7 +44,7 @@ public class WebSecurityConfiguracao {
                 .and()
                 .authorizeRequests()
                 .requestMatchers(HttpMethod.POST,
-                        "/login", "/pessoas/envia-codigo/**", "/pessoas/valida-codigo","/pessoas/auto"
+                        "/login", "/pessoas/envia-codigo/**", "/pessoas/valida-codigo","/pessoas/auto", "/pessoas/auto/envio-emails"
                 ).permitAll()
                 .requestMatchers(HttpMethod.PUT, "/pessoas/{id}/senha").permitAll()
                 .requestMatchers(HttpMethod.GET,

--- a/src/main/java/reserva_api/utils/Constantes.java
+++ b/src/main/java/reserva_api/utils/Constantes.java
@@ -1,0 +1,12 @@
+package reserva_api.utils;
+
+import reserva_api.models.ComunicacaoInternaModel;
+import reserva_api.models.PessoaModel;
+
+import java.text.MessageFormat;
+
+public class Constantes {
+    public static String urlFront = "http://localhost:3000";
+    public static String adminEmail = "josilenevitoriasilva@gmail.com"; // patrimonioicet@ufam.edu.br
+
+}

--- a/src/main/java/reserva_api/utils/MensagemEmailUtil.java
+++ b/src/main/java/reserva_api/utils/MensagemEmailUtil.java
@@ -7,24 +7,40 @@ import reserva_api.models.PessoaModel;
 import java.text.MessageFormat;
 
 public class  MensagemEmailUtil {
-    private static String urlFront = "http://localhost:3000";
-
     public static String ativacaoUsuario(PessoaModel pessoa) {
         return
                 MessageFormat.format("<h2>Seja bem-vindo (a), {0}!</h2><p>Sua conta foi registrada com sucesso nos <strong>Sistema GPMM</strong> pelo adminstrador!</p><p>Para ter acesso ao sistema, por favor acesse ao <a href=''{1}/primeiro-acesso/?email={2}''>site</a> e infome o código abaixo:</p></br><h3><strong>{3}</strong></h3><p>Atenciosamente,</p><p><strong>Equipe do Sistema GPMM</strong></p>",
-                        pessoa.getNome(), urlFront, pessoa.getEmail(), pessoa.getCodigoAtivacao());
+                        pessoa.getNome(), Constantes.urlFront, pessoa.getEmail(), pessoa.getCodigoAtivacao());
     }
 
     public static String envioCodigoUsuario(PessoaModel pessoa) {
         return
                 MessageFormat.format("<h2>Ola, {0}!</h2><p>O código para ativação da sua conta foi gerado.</p><p>Para ter acesso ao <strong>Sistema GPMM</strong>, por favor acesse ao <a href=''{1}/primeiro-acesso/?email={2}''>site</a> e infome o código abaixo:</p></br><h3><strong>{3}</strong></h3><p>Atenciosamente,</p><p><strong>Equipe do Sistema GPMM</strong></p>",
-                        pessoa.getNome(), urlFront, pessoa.getEmail(), pessoa.getCodigoAtivacao());
+                        pessoa.getNome(), Constantes.urlFront, pessoa.getEmail(), pessoa.getCodigoAtivacao());
+    }
+
+    public static String usuarioAutoCadastrado(PessoaModel solicitante) {
+        return
+                MessageFormat.format("<h2>Ola, {0}!</h2><p>Uma solicitação para liberação de acesso ao <strong>Sistema GPMM</strong> foi enviada ao administrador do sistema.</p><p>Em caso de atualizações, entraremos em contato.</p><p>Atenciosamente,</p><p><strong>Equipe do Sistema GPMM</strong></p>",
+                        solicitante.getNome());
+    }
+
+    public static String pedidoAutoCadastro(PessoaModel solicitante) {
+        return
+                MessageFormat.format("<h2>Ola, Admin!</h2><p>Uma nova solicitação de cadastro para o <strong>Sistema GPMM</strong> foi enviada pelo seginte usuário:</p><p><strong>Nome: </strong>{0}<br><strong>Siape: </strong>{1}<br><strong>E-mail: </strong>{2}</p><p>Para efetivar a ativação do mesmo, por favor, entre no sistema.</p><p>Atenciosamente,</p><p><strong>Equipe do Sistema GPMM</strong></p>",
+                        solicitante.getNome(), solicitante.getSiape(), solicitante.getEmail());
     }
 
     public static String recuperacaoConta(PessoaModel pessoa) {
         return
                 MessageFormat.format("<h2>Ola, {0}!</h2><p>Um novo código para recuperação da sua conta foi gerado.</p><p>Para ter acesso ao <strong>Sistema GPMM</strong>, por favor acesse ao <a href=''{1}/definir-rota/?email={2}''>site</a> e infome o código abaixo:</p></br><h3><strong>{3}</strong></h3><p>Atenciosamente,</p><p><strong>Equipe do Sistema GPMM</strong></p>",
-                        pessoa.getNome(), urlFront, pessoa.getEmail(), pessoa.getCodigoAtivacao());
+                        pessoa.getNome(), Constantes.urlFront, pessoa.getEmail(), pessoa.getCodigoAtivacao());
+    }
+
+    public static String envioUpdateStatus(PessoaModel pessoa) {
+        return
+                MessageFormat.format("<h2>Ola, {0}!</h2><p>O status da sua conta no <strong>Sistema GPMM</strong> foi mudado para <strong>{1}</strong> pelo administrador do sistema.</p><p>Atenciosamente,</p><p><strong>Equipe do Sistema GPMM</strong></p>",
+                        pessoa.getNome(), pessoa.getStatus());
     }
 
     public static String solicitacaoComunicacaoInterna(ComunicacaoInternaModel comunicacoInterna) {


### PR DESCRIPTION
Esta PR implementa os seguintes itens:

- Criação de rota para envio de email ADMIN como aviso de novo auto cadastro e envio para o usuário (`/pessoas/auto/envio-emails`);
- Criação de rota para envio de email para usuário avisando de mudança de status na sua conta (`/pessoas/status/envio-email`).  
